### PR TITLE
#3 implementing the node bootstrapping role

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: firstset # use my own github account for testing for now
 name: fogo_community
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.0.2
+version: 0.0.3
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/node_bootstrapping/README.md
+++ b/roles/node_bootstrapping/README.md
@@ -1,0 +1,23 @@
+# Fogo Validator Node Bootstrapping
+
+Improve node-level observability and harden the security of a Fogo validator node.
+
+## Role Variables
+
+All variables which can be overridden are stored in `defaults/main.yml`. Please also check the Firedancer config template and its systemd definition file in the `templates` folder.
+
+## Dependencies
+
+- prometheus.prometheus: <https://galaxy.ansible.com/ui/repo/published/prometheus/prometheus/>
+
+## Examples
+
+TODO
+
+## License
+
+MIT
+
+## Author Information
+
+<https://www.firstset.xyz/>

--- a/roles/node_bootstrapping/README.md
+++ b/roles/node_bootstrapping/README.md
@@ -1,10 +1,21 @@
 # Fogo Validator Node Bootstrapping
 
-Improve node-level observability and harden the security of a Fogo validator node.
+Bootstrap and harden Fogo validator nodes with security configurations, monitoring, and user management.
+
+## Requirements
+
+Target nodes should be Ubuntu/Debian-based systems with sudo access.
 
 ## Role Variables
 
-All variables which can be overridden are stored in `defaults/main.yml`. Please also check the Firedancer config template and its systemd definition file in the `templates` folder.
+All variables which can be overridden are stored in `defaults/main.yml`.
+
+### Default Variables
+
+- `prometheus_node_ip`: IP address of the Prometheus server to whitelist for metrics scraping (default: `null`)
+- `enable_ufw`: Whether to enable UFW firewall after configuration (default: `false`)
+- `ssh_port_number`: SSH port to use instead of default port 22 (default: `156`)
+- `sudo_users`: Dictionary of sudo users to create with their SSH public keys
 
 ## Dependencies
 
@@ -12,7 +23,51 @@ All variables which can be overridden are stored in `defaults/main.yml`. Please 
 
 ## Examples
 
-TODO
+### Bootstrap a validator node with security hardening
+
+This role performs the following tasks:
+- Creates sudo users with SSH key authentication
+- Configures SSH security (disables root login, password authentication)
+- Changes SSH port for enhanced security
+- Installs and configures fail2ban for intrusion prevention
+- Sets up UFW firewall with default deny policy
+- Installs Prometheus node exporter for monitoring
+- Whitelists Prometheus server for metrics collection
+
+```yml
+- name: Bootstrap Fogo Validator Node
+  hosts: all
+  become: true
+  vars:
+    sudo_users:
+      admin1: "ssh-rsa AAAAB3NzaC1yc2E... user1@example.com"
+      admin2: "ssh-rsa AAAAB3NzaC1yc2E... user2@example.com"
+    prometheus_node_ip: "10.0.1.100"
+    enable_ufw: true
+    ssh_port_number: 156
+
+  roles:
+    - firstset.fogo_community.node_bootstrapping
+```
+
+### Basic setup with minimal configuration
+
+```yml
+- name: Basic Node Bootstrapping
+  hosts: all
+  become: true
+
+  roles:
+    - firstset.fogo_community.node_bootstrapping
+```
+
+### Enable UFW firewall after configuration
+
+By default, UFW rules are configured but UFW remains disabled. To enable UFW after setup, either specify it in the inventory/playbook, or use the following command:
+
+```bash
+ansible-playbook -i inventory/fogo.yml playbooks/bootstrap.yml --ask-become-pass -e "enable_ufw=true"
+```
 
 ## License
 

--- a/roles/node_bootstrapping/defaults/main.yml
+++ b/roles/node_bootstrapping/defaults/main.yml
@@ -1,0 +1,10 @@
+#SPDX-License-Identifier: MIT
+---
+# defaults file for node_bootstrapping
+
+# the Prometheus server's IP address that should be whitelisted
+prometheus_node_ip: null
+# whether enable UFW automatically after running the tasks
+enable_ufw: false
+# switch to use the following port for SSH connections instead of port 22
+ssh_port_number: 156

--- a/roles/node_bootstrapping/handlers/main.yml
+++ b/roles/node_bootstrapping/handlers/main.yml
@@ -1,0 +1,18 @@
+#SPDX-License-Identifier: MIT
+---
+# handlers file for node_bootstrapping
+- name: Restart SSH
+  service:
+    name: ssh
+    state: restarted
+
+- name: Restart ssh.socket
+  systemd_service:
+    name: ssh.socket
+    daemon_reload: true
+    state: restarted
+
+- name: restart fail2ban
+  service:
+    name: fail2ban
+    state: restarted

--- a/roles/node_bootstrapping/meta/main.yml
+++ b/roles/node_bootstrapping/meta/main.yml
@@ -1,0 +1,21 @@
+#SPDX-License-Identifier: MIT
+galaxy_info:
+  author: Firstset
+  description: FOGO validator node bootstrapping
+  company: Firstset
+
+  license: MIT
+
+  min_ansible_version: "2.9"
+
+  galaxy_tags:
+    - fogo
+    - validator
+    - node
+    - observability
+    - security
+
+dependencies:
+  []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/roles/node_bootstrapping/tasks/create_sudo_users.yml
+++ b/roles/node_bootstrapping/tasks/create_sudo_users.yml
@@ -1,0 +1,45 @@
+- name: Check if user {{ sudo_username }} exists
+  become: true
+  command: getent passwd "{{ sudo_username }}"
+  register: user_exists
+  check_mode: false
+  ignore_errors: true
+
+- name: Generate a random password (like a placeholder) that will be set expired in this execution
+  set_fact:
+    sudo_user_password: "{{ lookup('ansible.builtin.password', '/dev/null', length=8, chars=['ascii_letters', 'digits']) }}"
+  run_once: true
+
+- name: Send the following one-time password to the user {{ sudo_username }}, which is needed for creating the real password
+  ansible.builtin.debug:
+    msg: "{{ sudo_user_password }}"
+  run_once: true
+
+- name: Create user {{ sudo_username }} with a random, expired password
+  become: true
+  user:
+    name: "{{ sudo_username }}"
+    shell: "/bin/bash"
+    create_home: yes
+    password: "{{ sudo_user_password | password_hash('sha512') }}" # Locked password
+  when: user_exists.rc != 0 # return code is non-zero which means the user does not exist yet
+
+- name: Expire password to force change on first login
+  become: true
+  command: "chage -d 0 {{ sudo_username }}"
+  when: user_exists.rc != 0
+
+- name: Add user {{ sudo_username }} to sudo group
+  become: true
+  user:
+    name: "{{ sudo_username }}"
+    groups: sudo
+    append: yes
+
+- name: Add SSH pub key to the user's `authorized_key` file
+  become: true
+  authorized_key:
+    user: "{{ sudo_username }}"
+    state: present
+    key: "{{ sudo_user_pubkey }}"
+  ignore_errors: true

--- a/roles/node_bootstrapping/tasks/main.yml
+++ b/roles/node_bootstrapping/tasks/main.yml
@@ -1,0 +1,21 @@
+#SPDX-License-Identifier: MIT
+---
+# tasks file for node_bootstrapping
+- name: Sudo user management
+  include_tasks: sudo_user_management.yml
+
+- name: Install Prometheus node exporter
+  ansible.builtin.include_role:
+    name: prometheus.prometheus.node_exporter
+
+- name: Whitelist Prometheus server IP for scraping
+  community.general.ufw:
+    rule: allow
+    direction: in
+    src: "{{ prometheus_node_ip }}"
+    comment: prometheus scrape
+    to_port: 9100
+  when: prometheus_node_ip is not none
+
+- name: Hardening node's security
+  include_tasks: security_hardening.yml

--- a/roles/node_bootstrapping/tasks/security_hardening.yml
+++ b/roles/node_bootstrapping/tasks/security_hardening.yml
@@ -1,0 +1,135 @@
+- name: Update repositories cache and install fail2ban
+  become: true
+  apt:
+    name: fail2ban
+    update_cache: yes
+
+- name: Ensure fail2ban is running and enabled
+  become: true
+  systemd:
+    name: fail2ban
+    state: started
+    enabled: yes
+  ignore_errors: "{{ ansible_check_mode }}"
+
+- name: Install ufw
+  become: true
+  package:
+    name: ufw
+    state: present
+
+- name: Check wether enabling UFW would be considered as changed, meaning that currently ufw is not active
+  become: true
+  check_mode: true
+  community.general.ufw:
+    state: enabled
+  register: ufw_enable_check
+
+- name: Debug message for UFW check
+  debug:
+    msg: >
+      {% if ufw_enable_check.changed %}
+        UFW is not enabled, proceeding with adding necessary rules (keep UFW disabled by default)
+        You can use `enable_ufw=true` to enable UFW besides updating the rules.
+      {% else %}
+        Currently UFW is already enabled, proceeding with adding necessary rules.
+      {% endif %}
+
+- name: Set ufw default policies
+  become: true
+  community.general.ufw:
+    direction: "{{ item.direction }}"
+    policy: "{{ item.policy }}"
+  loop:
+    - { direction: incoming, policy: deny }
+    - { direction: outgoing, policy: allow }
+
+- name: Checking ssh_port_number
+  debug:
+    msg:
+      - "The SSH connection port is configured with var ssh_port_number (default value 22)"
+      - "Value for this host: {{ ssh_port_number }}"
+
+- name: Allow SSH connections
+  become: true
+  community.general.ufw:
+    rule: allow
+    port: "{{ ssh_port_number }}"
+    proto: tcp
+    comment: ssh
+
+- name: Enable ufw
+  become: true
+  community.general.ufw:
+    state: enabled
+  when: enable_ufw
+
+- name: Disable SSH password authentication
+  become: true
+  lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: "^#?PasswordAuthentication"
+    line: "PasswordAuthentication no"
+    state: present
+  notify: Restart SSH
+
+- name: Change sshd listening port if ssh_port_number is not 22, and restart SSH
+  become: true
+  lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: "^#?Port "
+    line: "Port {{ ssh_port_number }}"
+    state: present
+  notify: Restart SSH
+  when: ssh_port_number != 22
+
+- name: Update ssh.socket config to listen on the configured port if it exists
+  become: true
+  lineinfile:
+    path: /usr/lib/systemd/system/ssh.socket
+    regexp: "^ListenStream="
+    line: "ListenStream={{ ssh_port_number }}"
+    state: present
+  register: update_ssh_socket_config_result
+  when: ssh_port_number != 22
+
+- name: Check if ssh.socket exists
+  command: systemctl is-active ssh.socket
+  register: ssh_socket_status
+  check_mode: false
+  ignore_errors: true
+
+- name: Restart ssh.socket
+  become: true
+  debug:
+    msg:
+      - "ssh.socket service is active thus it needs to be restarted"
+  notify: Restart ssh.socket
+  when: ssh_socket_status.rc == 0 and update_ssh_socket_config_result.changed
+  changed_when: true
+
+- name: Override Fail2Ban SSH jail when port is non-standard
+  become: true
+  ansible.builtin.template:
+    src: sshd-jail.conf.j2
+    dest: /etc/fail2ban/jail.d/10-sshd-port.conf
+    owner: root
+    group: root
+    mode: '0644'
+  when: ssh_port_number != 22
+  notify: restart fail2ban
+
+- name: Remove Fail2Ban custom jail if SSH port changed back to 22
+  become: true
+  ansible.builtin.file:
+    path: /etc/fail2ban/jail.d/10-sshd-port.conf
+    state: absent
+  when: ssh_port_number == 22
+  notify: restart fail2ban
+
+- name: Reminder
+  debug:
+    msg:
+      - "Please note that SSH port has been changed to {{ ssh_port_number }}."
+      - "Don't forget to update your `ssh_config` file."
+  when: ssh_port_number != 22

--- a/roles/node_bootstrapping/tasks/sudo_user_management.yml
+++ b/roles/node_bootstrapping/tasks/sudo_user_management.yml
@@ -1,0 +1,30 @@
+- name: Create a sudo user with forced password change on first login
+  include_tasks: create_sudo_users.yml
+  vars:
+    sudo_username: "{{ item.key }}"
+    sudo_user_pubkey: "{{ item.value }}"
+  with_dict: "{{ sudo_users }}"
+
+- name: Only allow these sudo users to ssh
+  become: true
+  lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: "^AllowUsers"
+    line: "AllowUsers {{ sudo_users.keys() | join(' ') }}"
+    state: present
+    create: yes
+  when: sudo_users is defined
+
+- name: Ensure root login is disabled in SSH config since we have created sudo users
+  become: true
+  lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: "^#?PermitRootLogin"
+    line: "PermitRootLogin no"
+    state: present
+  when: sudo_users is defined
+
+- name: Restart SSH service
+  service:
+    name: ssh
+    state: restarted

--- a/roles/node_bootstrapping/templates/sshd-jail.conf.j2
+++ b/roles/node_bootstrapping/templates/sshd-jail.conf.j2
@@ -1,0 +1,3 @@
+[sshd]
+enabled = true
+port    = {{ ssh_port_number }}

--- a/roles/node_bootstrapping/tests/inventory
+++ b/roles/node_bootstrapping/tests/inventory
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT
+localhost
+

--- a/roles/node_bootstrapping/tests/test.yml
+++ b/roles/node_bootstrapping/tests/test.yml
@@ -3,4 +3,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - validator_service
+    - node_bootstrapping

--- a/roles/node_bootstrapping/vars/main.yml
+++ b/roles/node_bootstrapping/vars/main.yml
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT
+---
+# vars file for node_bootstrapping


### PR DESCRIPTION
This new role performs the following tasks:
- Creates sudo users with SSH key authentication
- Configures SSH security (disables root login, password authentication)
- Changes SSH port for enhanced security
- Installs and configures fail2ban for intrusion prevention
- Sets up UFW firewall with default deny policy
- Installs Prometheus node exporter for monitoring
- Whitelists Prometheus server for metrics collection