### PR TITLE
#2 roll out configuration changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,34 @@ ansible-galaxy collection install firstset-fogo_community-*.tar.gz
 
 ## Quick Start
 
+### Node Bootstrapping
+
+Create a playbook to bootstrap the node, including sudo user creation, SSH hardening, Node Exporter installation, and firewall setup:
+
+```yaml
+- name: Bootstrap Fogo Validator Node
+  hosts: all
+  become: true
+  vars:
+    sudo_users:
+      admin1: "ssh-rsa AAAAB3NzaC1yc2E... user1@example.com"
+      admin2: "ssh-rsa AAAAB3NzaC1yc2E... user2@example.com"
+    prometheus_node_ip: "10.0.1.100"
+    enable_ufw: true
+    ssh_port_number: 156
+
+  roles:
+    - firstset.fogo_community.node_bootstrapping
+```
+
+Run the playbook:
+
+```bash
+ansible-playbook -i inventory bootstrap-node.yml --ask-become-pass
+```
+
+In this example, we change the SSH port to `156`, so don't forget to update your SSH client configuration accordingly. The `prometheus_node_ip` should be set to the IP address of your Prometheus server for metrics collection.
+
 ### Basic Validator Setup
 
 Create a playbook to deploy a FOGO validator:
@@ -70,7 +98,7 @@ Create a playbook to deploy a FOGO validator:
 Run the playbook:
 
 ```bash
-ansible-playbook -i inventory site.yml --ask-become-pass
+ansible-playbook -i inventory deploy-service.yml --ask-become-pass
 ```
 
 ### Advanced Configuration

--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ Then the following command can be used for only updating the configuration file 
 ansible-playbook site.yml -t update_config --ask-become-pass
 ```
 
+The tag `update_config` also works for overriding the systemd definition file. The corresponding variable is `firedancer_systemd_template_path` which defaults to `templates/firedancer_systemd.j2`.
+
 ## Repository Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -122,6 +122,29 @@ Override default settings by setting variables:
 
 ## Included Roles
 
+### `node_bootstrapping`
+
+The main role for bootstrapping a FOGO validator node. See the [role documentation](roles/node_bootstrapping/README.md) for detailed configuration options and examples.
+
+**Key tasks performed:**
+
+- Sudo user creation with SSH key authentication
+- SSH security hardening (disable root/password login)
+- SSH port configuration for enhanced security
+- Fail2ban installation and configuration
+- UFW firewall setup with default deny policy
+- Prometheus node exporter installation
+- Network security rules and monitoring integration
+
+**Role variables:**
+
+| Variable             | Default | Description                                                   |
+| -------------------- | ------- | ------------------------------------------------------------- |
+| `prometheus_node_ip` | `null`  | IP address of the Prometheus server to whitelist for metrics  |
+| `enable_ufw`         | `false` | Whether to enable UFW firewall after configuration            |
+| `ssh_port_number`    | `156`   | SSH port to use instead of default port 22                    |
+| `sudo_users`         | `{}`    | Dictionary of sudo users to create with their SSH public keys |
+
 ### `validator_service`
 
 The main role for deploying and managing FOGO validators. See the [role documentation](roles/validator_service/README.md) for detailed configuration options and examples.
@@ -137,39 +160,59 @@ The main role for deploying and managing FOGO validators. See the [role document
 - Configuration file generation
 - Systemd service setup and activation
 
-## Configuration
-
 All configurable variables are documented in [`roles/validator_service/defaults/main.yml`](roles/validator_service/defaults/main.yml). Key variables include:
 
 | Variable                            | Default                                    | Description                                                                                               |
 | ----------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
-| `validator_client_version`          | `v6.0.0`                                   | FOGO release version to install                                                                           |
-| `validator_client_tarfile_checksum` | `817533105183734d5f4dffb4f0b11b0de2adf38b` | The SHA1 checksum of the source code tar file provided by FOGO [here](https://docs.fogo.io/releases.html) |
+| `validator_client_version`          | `v7.0.0`                                   | FOGO release version to install                                                                           |
+| `validator_client_tarfile_checksum` | `7d2ca6e4e47bf31ffd1c4e04634895acd820984d` | The SHA1 checksum of the source code tar file provided by FOGO [here](https://docs.fogo.io/releases.html) |
 | `service_user`                      | `fogo`                                     | System user for the validator service                                                                     |
 | `firedancer_gossip_port`            | `8001`                                     | Port for gossip network communication                                                                     |
 | `bootstrap_disks`                   | `false`                                    | Whether to detect and format additional disks                                                             |
-| `upgrade_only`                      | `false`                                    | Only upgrade binaries without full setup                                                                  |
 
-## Common Usage Patterns
+The role also provides two tags `update_binary` and `update_config` for filtering the tasks during execution. Use these tags to update the Firedancer binary or configuration without re-running the entire playbook. Check the common use cases below.
 
-### Initial Deployment
+#### Common Usage Patterns
+
+##### Initial Deployment
 
 ```bash
 # Full setup including disk bootstrapping
 ansible-playbook site.yml -e "bootstrap_disks=true" --ask-become-pass
 ```
 
-### Binary Upgrades
+##### Binary Upgrades
 
 ```bash
 # Upgrade to new version
-ansible-playbook site.yml -e "upgrade_only=true validator_client_version=v6.1.0 validator_client_tarfile_checksum=817533105183734d5f4dffb4f0b11b0de2adf38b" --ask-become-pass
+ansible-playbook site.yml -t update_binary -e "validator_client_version=v7.0.0 validator_client_tarfile_checksum=7d2ca6e4e47bf31ffd1c4e04634895acd820984d" --ask-become-pass
+```
+
+##### Config Updates
+
+The role already includes a FOGO firedancer config template that you can find in `templates/firedancer_config_template.toml.j2`. If you need to override the config, first create your own template file and set the variable `firedancer_config_template_path` to point to your custom template. For example:
+
+```yaml
+- name: Deploy FOGO Validator
+  hosts: validator_nodes
+  become: true
+  vars:
+    firedancer_config_template_path: "./templates/my_fogo_service_config.toml.j2"
+  roles:
+    - firstset.fogo_community.validator_service
+```
+
+Then the following command can be used for only updating the configuration file and restarting the service:
+
+```bash
+ansible-playbook site.yml -t update_config --ask-become-pass
 ```
 
 ## Repository Structure
 
 ```
 ├── roles/
+│   ├── node_bootstrapping/    # Node bootstrapping role
 │   └── validator_service/     # Main validator deployment role
 ├── galaxy.yml                 # Collection metadata
 ├── LICENSE                    # MIT license

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: firstset # use my own github account for testing for now
 name: fogo_community
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.0.3
+version: 0.0.4
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/validator_service/README.md
+++ b/roles/validator_service/README.md
@@ -45,18 +45,18 @@ Building Firedancer binary is included by default. The version and the release c
   hosts: all
   become: true
 +  vars:
-+    # use v6.0.0 as an example here
-+    validator_client_version: v6.0.0
-+    validator_client_tarfile_checksum: 817533105183734d5f4dffb4f0b11b0de2adf38b
++    # use v7.0.0 as an example here
++    validator_client_version: v7.0.0
++    validator_client_tarfile_checksum: 7d2ca6e4e47bf31ffd1c4e04634895acd820984d
 
   roles:
     - firstset.fogo_community.validator_service
 ```
 
-Then specify `upgrade_only=true` when you run the playbook:
+Then specify the tag `update_binary` when you run the playbook:
 
 ```bash
-ansible-playbook -i inventory/fogo.yml playbooks/fogo.yml --ask-become-pass -e "upgrade_only=true"
+ansible-playbook -i inventory/fogo.yml playbooks/fogo.yml --ask-become-pass -t update_binary
 ```
 
 ## License

--- a/roles/validator_service/README.md
+++ b/roles/validator_service/README.md
@@ -59,6 +59,28 @@ Then specify the tag `update_binary` when you run the playbook:
 ansible-playbook -i inventory/fogo.yml playbooks/fogo.yml --ask-become-pass -t update_binary
 ```
 
+### Update FOGO Firedancer Configuration
+
+The role already includes a FOGO firedancer config template that you can find in `templates/firedancer_config_template.toml.j2`. If you need to override the config, first create your own template file and set the variable `firedancer_config_template_path` to point to your custom template. For example:
+
+```yaml
+- name: Deploy FOGO Validator
+  hosts: validator_nodes
+  become: true
+  vars:
+    firedancer_config_template_path: "./templates/my_fogo_service_config.toml.j2"
+  roles:
+    - firstset.fogo_community.validator_service
+```
+
+Then the following command can be used for only updating the configuration file and restarting the service:
+
+```bash
+ansible-playbook site.yml -t update_config --ask-become-pass
+```
+
+The tag `update_config` also works for overriding the systemd definition file. The corresponding variable is `firedancer_systemd_template_path` which defaults to `templates/firedancer_systemd.j2`.
+
 ## License
 
 MIT

--- a/roles/validator_service/defaults/main.yml
+++ b/roles/validator_service/defaults/main.yml
@@ -4,10 +4,12 @@
 bootstrap_disks: false
 enable_cpu_performance_mode: true
 service_user: fogo
-validator_client_version: v6.0.0
-validator_client_tarfile_checksum: 817533105183734d5f4dffb4f0b11b0de2adf38b
+validator_client_version: v7.0.0
+validator_client_tarfile_checksum: 7d2ca6e4e47bf31ffd1c4e04634895acd820984d
 firedancer_config_path: "/home/{{ service_user }}/firedancer-config.toml"
 identity_path: "/home/{{ service_user }}/unstaked-identity.json"
+firedancer_config_template_path: "firedancer_config_template.toml.j2"
+firedancer_systemd_template_path: "firedancer_systemd.j2"
 
 # The OS may be installed on the ledger disk, though testing has shown better performance with the ledger on its own disk
 # Accounts and ledger can be stored on the same disk, however due to high IOPS, this is not recommended
@@ -20,6 +22,3 @@ accounts_path: "/mnt/accounts"
 
 firedancer_gossip_port: 8001
 firedancer_dynamic_port_range: 8901-9000
-
-# If `upgrade_only` is set to true, the role only builds and replaces the binaries and then restarts the service
-upgrade_only: false

--- a/roles/validator_service/tasks/build_fogo_fd_client.yml
+++ b/roles/validator_service/tasks/build_fogo_fd_client.yml
@@ -2,17 +2,23 @@
   ansible.builtin.file:
     path: "{{ temp_source_code_folder }}"
     state: absent
+  tags:
+    - update_binary
 
 - name: Recreate the temporary source code folder {{ temp_source_code_folder }}
   ansible.builtin.file:
     path: "{{ temp_source_code_folder }}"
     state: directory
+  tags:
+    - update_binary
 
 - name: Download the release tar file
   get_url:
     url: "https://static.fogo.io/fogo-{{ validator_client_version }}.tar.gz"
     dest: /tmp
     checksum: "sha1:{{ validator_client_tarfile_checksum }}"
+  tags:
+    - update_binary
 
 - name: Extract the files from the tar file
   ansible.builtin.unarchive:
@@ -22,6 +28,8 @@
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
     remote_src: true
+  tags:
+    - update_binary
 
 - name: Run deps.sh to install dependencies
   become: true
@@ -30,6 +38,8 @@
   args:
     chdir: "{{ temp_source_code_folder }}/fogo"
   ignore_errors: true
+  tags:
+    - update_binary
 
 - name: Build fdctl binary
   become: true
@@ -42,13 +52,17 @@
   retries: 2
   until: make_result.rc == 0
   delay: 5
+  tags:
+    - update_binary
 
 - name: Stop fogo validator as this is an upgrade task
   systemd_service:
     name: fogo-validator
     daemon_reload: true
     state: stopped
-  when: upgrade_only
+  tags:
+    - never
+    - update_binary
 
 - name: Copy fdctl binary to /usr/local/bin
   become: true
@@ -59,3 +73,5 @@
     mode: "0755"
   notify:
     - Restart fogo validator service
+  tags:
+    - update_binary

--- a/roles/validator_service/tasks/main.yml
+++ b/roles/validator_service/tasks/main.yml
@@ -81,6 +81,8 @@
     src: "{{ firedancer_systemd_template_path }}"
     dest: "/etc/systemd/system/fogo-validator.service"
     mode: "0644"
+  tags:
+    - update_config
 
 - name: Enable and start fogo validator
   systemd_service:
@@ -88,3 +90,5 @@
     daemon_reload: true
     enabled: true
     state: started
+  tags:
+    - update_config

--- a/roles/validator_service/tasks/main.yml
+++ b/roles/validator_service/tasks/main.yml
@@ -6,19 +6,17 @@
     name:
       - acl
     update_cache: yes
-  when: not upgrade_only
 
 - name: Bootstrap disks (which should be run only once)
   include_tasks: bootstrap_disks.yml
-  when: bootstrap_disks and not upgrade_only
+  when: bootstrap_disks
 
 - name: Conditionally include CPU performance tasks
   include_tasks: cpu_performance_mode.yml
-  when: enable_cpu_performance_mode and not upgrade_only
+  when: enable_cpu_performance_mode
 
 - name: Update UFW settings for Firedancer
   include_tasks: ufw_settings.yml
-  when: not upgrade_only
 
 - name: Create a service user
   become: true
@@ -28,7 +26,6 @@
     create_home: true
     password: "!"
     state: present
-  when: not upgrade_only
 
 - name: Update repositories cache and install required libraries
   become: true
@@ -45,21 +42,25 @@
       - libudev-dev
       - protobuf-compiler
     update_cache: yes
-  when: not upgrade_only
 
 - name: Build fogo firedancer client
   include_tasks: build_fogo_fd_client.yml
   vars:
     temp_source_code_folder: "/home/{{ service_user }}/fogo-{{ validator_client_version }}"
+  tags:
+    - update_binary
 
 - name: Generate firedancer config from the template
   template:
-    src: firedancer_config_template.toml.j2
+    src: "{{ firedancer_config_template_path }}"
     dest: "{{ firedancer_config_path }}"
     mode: "0644"
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
-  when: not upgrade_only
+  notify:
+    - Restart fogo validator service
+  tags:
+    - update_config
 
 - name: Check the existence of the key files
   block:
@@ -73,15 +74,13 @@
       become_user: "{{ service_user }}"
       shell: "fdctl keys new identity --config {{ firedancer_config_path }}"
       when: not identity_keypair_stat.stat.exists
-  when: not upgrade_only
 
 - name: Create the systemd service for fogo
   become: true
   template:
-    src: firedancer_systemd.j2
+    src: "{{ firedancer_systemd_template_path }}"
     dest: "/etc/systemd/system/fogo-validator.service"
     mode: "0644"
-  when: not upgrade_only
 
 - name: Enable and start fogo validator
   systemd_service:
@@ -89,4 +88,3 @@
     daemon_reload: true
     enabled: true
     state: started
-  when: not upgrade_only


### PR DESCRIPTION
Implemented by tagging specific tasks with `update_config`. This PR also changes the previous implementation for binary updates, from using a variable to using a tag (`update_binary`).