### PR TITLE
#6 add operations role for checking node states

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,10 +215,11 @@ The tag `update_config` also works for overriding the systemd definition file. T
 ```
 ├── roles/
 │   ├── node_bootstrapping/    # Node bootstrapping role
-│   └── validator_service/     # Main validator deployment role
+│   ├── validator_service/     # Main validator deployment role
+│   └── operations/            # Operations role
 ├── galaxy.yml                 # Collection metadata
 ├── LICENSE                    # MIT license
-└── README.md                 # This file
+└── README.md                  # This file
 ```
 
 ## Contributing

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: firstset # use my own github account for testing for now
 name: fogo_community
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.0.4
+version: 0.0.5
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/callback/report.py
+++ b/plugins/callback/report.py
@@ -1,0 +1,30 @@
+# Make coding more python3-ish, this is required for contributions to Ansible
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+from ansible.plugins.callback import CallbackBase
+
+
+class CallbackModule(CallbackBase):
+    """
+    This callback module pretty-prints the host report for Fogo validator nodes.
+    """
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = "aggregate"
+    CALLBACK_NAME = "firstset.fogo_community.report"
+
+    # only needed if you ship it and don't want to enable by default
+    CALLBACK_NEEDS_ENABLED = True
+
+    def v2_runner_on_ok(self, result):
+        role = getattr(result._task, "_role", None)
+        if (
+            str(role) == "firstset.fogo_community.operations"
+            and str(result.task_name) == "Set fact host_report"
+        ):
+            facts = result._result.get("ansible_facts", {})
+            report = facts["host_report"]
+            self._display.display(f"[{result._host.get_name()}] HOST REPORT:\n{report}")
+        else:
+            return

--- a/roles/operations/README.md
+++ b/roles/operations/README.md
@@ -8,15 +8,118 @@ Target nodes should be Ubuntu/Debian-based systems with sudo access.
 
 ## Role Variables
 
-TODO
+All variables which can be overridden are stored in `defaults/main.yml`.
 
-## Dependencies
+### systemd_services_to_check
 
-TODO
+List of systemd services to check status and logs for.
+
+Default:
+
+```yaml
+systemd_services_to_check:
+  - fail2ban
+  - node_exporter
+  - fogo-validator
+```
+
+### binaries_to_check
+
+Dictionary of binaries to check versions for, including their path and version command option.
+
+Default:
+
+```yaml
+binaries_to_check:
+  fdctl:
+    path: /usr/local/bin/fdctl
+    option: version
+```
 
 ## Examples
 
-TODO
+### Check fleet status and generate reports
+
+This role generates detailed reports about the status of key services and binaries on Fogo validator nodes.
+
+```yml
+- name: Generate Validator Nodes Report
+  hosts: validators
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Generate Validator Nodes Report
+      include_role:
+        name: firstset.fogo_community.operations
+        tasks_from: check_fleet.yml
+```
+
+The role will check:
+
+- Systemd service status (active state and unit file state)
+- Recent log entries (last 10 lines) for each service
+- Binary versions for key executables
+- Kernel version
+
+The report for each Fogo validator node is set as a fact named `host_report`. There are several approaches to get the content of the report.
+
+#### use the report plugin
+
+This collection also ships a plugin called `firstset.fogo_community.report` that helps pretty-print the Fogo validator node report. To enable it, add the following into your `ansible.cfg` file in your playbooks folder:
+
+```
+[defaults]
+callbacks_enabled = firstset.fogo_community.report
+```
+
+By doing this, everytime when the tasks in `check_fleet.yml` are executed and the fact `host_report` is set successfully, the report will be printed to the console in a human-readable format.
+
+#### use the debug module
+
+You can also output the report using the Ansible `debug` module:
+
+```yml
+- name: Output report
+  debug:
+    msg: "{{ host_report.split('\n') }}"
+```
+
+#### dump the report to a file
+
+```yml
+- name: Output report to a file
+  become: false
+  copy:
+    content: "{{ host_report }}"
+    dest: "./host_report_{{ inventory_hostname }}.txt"
+  delegate_to: localhost
+```
+
+### Custom service and binary checks
+
+You can override the default services and binaries to check:
+
+```yml
+- name: Custom Fleet Check
+  hosts: validators
+  become: true
+  vars:
+    systemd_services_to_check:
+      - fogo-validator
+      - prometheus
+      - grafana
+    binaries_to_check:
+      fdctl:
+        path: /usr/local/bin/fdctl
+        option: version
+      prometheus:
+        path: /usr/local/bin/prometheus
+        option: --version
+
+  roles:
+    - firstset.fogo_community.operations
+```
 
 ## License
 

--- a/roles/operations/README.md
+++ b/roles/operations/README.md
@@ -1,0 +1,27 @@
+# Fogo Validator Node Operations
+
+Common operations for Fogo validator nodes, such as checking key services running status, binaries versions, latest logs, etc.
+
+## Requirements
+
+Target nodes should be Ubuntu/Debian-based systems with sudo access.
+
+## Role Variables
+
+TODO
+
+## Dependencies
+
+TODO
+
+## Examples
+
+TODO
+
+## License
+
+MIT
+
+## Author Information
+
+<https://www.firstset.xyz/>

--- a/roles/operations/defaults/main.yml
+++ b/roles/operations/defaults/main.yml
@@ -1,0 +1,11 @@
+#SPDX-License-Identifier: MIT
+---
+# defaults file for operations
+systemd_services_to_check:
+  - fail2ban
+  - node_exporter
+  - fogo-validator
+binaries_to_check:
+  fdctl:
+    path: /usr/local/bin/fdctl
+    option: version

--- a/roles/operations/handlers/main.yml
+++ b/roles/operations/handlers/main.yml
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT
+---
+# handlers file for operations

--- a/roles/operations/meta/main.yml
+++ b/roles/operations/meta/main.yml
@@ -1,0 +1,20 @@
+#SPDX-License-Identifier: MIT
+galaxy_info:
+  author: Firstset
+  description: FOGO validator node operations
+  company: Firstset
+
+  license: MIT
+
+  min_ansible_version: "2.9"
+
+  galaxy_tags:
+    - fogo
+    - validator
+    - node
+    - observability
+    - security
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/roles/operations/tasks/check_fleet.yml
+++ b/roles/operations/tasks/check_fleet.yml
@@ -1,0 +1,63 @@
+---
+- name: Initialize reports
+  set_fact:
+    services_report: {}
+    binaries_report: {}
+
+- name: Collect state + status only for requested units
+  shell: systemctl show -p ActiveState -p UnitFileState --value {{ item }}.service
+  register: service_states
+  changed_when: false # read-only
+  failed_when: false # keep going if unit missing
+  loop: "{{ systemd_services_to_check }}"
+
+- name: Get log tail for services
+  shell: journalctl -u {{ item }}.service -n 10 --no-pager
+  register: service_logs
+  changed_when: false
+  failed_when: false
+  loop: "{{ systemd_services_to_check }}"
+
+- name: Build service_logs_dict from list
+  set_fact:
+    service_logs_dict: "{{ service_logs_dict | default({}) | combine({ item.item: item.stdout | default('log unavailable') }) }}"
+  loop: "{{ service_logs.results }}"
+  when: not item.skipped | default(false)
+  no_log: true
+
+- name: Build services_report
+  set_fact:
+    services_report: >-
+      {{ services_report | combine({
+        item.item: {
+          'active_state': item.stdout_lines[0] | default('unknown'),
+          'unit_file_state': item.stdout_lines[1] | default('unknown'),
+          'logs': service_logs_dict[item.item] | default('log unavailable')
+        }
+      }, recursive=True) }}
+  loop: "{{ service_states.results }}"
+  when: not item.skipped | default(false)
+  no_log: true
+
+- name: Get binary versions
+  command: "{{ item.value.path }} {{ item.value.option }}"
+  register: binary_versions
+  changed_when: false
+  failed_when: false
+  loop: "{{ binaries_to_check | dict2items }}"
+
+- name: Build binaries_report
+  set_fact:
+    binaries_report: "{{ binaries_report | combine({ item.item.key: item.stdout | default('unknown') }) }}"
+  loop: "{{ binary_versions.results }}"
+  when: not item.skipped | default(false)
+  no_log: true
+
+- name: Collect kernel version
+  command: uname -r
+  register: kernel_ver
+  changed_when: false
+
+- name: Set fact host_report
+  set_fact:
+    host_report: "{{ lookup('template', 'check_fleet_report.j2') }}"

--- a/roles/operations/tasks/main.yml
+++ b/roles/operations/tasks/main.yml
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT
+---
+# tasks file for operations

--- a/roles/operations/templates/check_fleet_report.j2
+++ b/roles/operations/templates/check_fleet_report.j2
@@ -1,0 +1,16 @@
+========= {{ inventory_hostname }} =========
+Kernel version: {{ kernel_ver.stdout }}
+Key services:
+
+{% for svc in systemd_services_to_check %}
+[{{ svc }}] active_state={{ services_report[svc].active_state }}, unit_file_state={{ services_report[svc].unit_file_state }}
+last 10 log lines:
+{{ services_report[svc].logs | indent(2) }}
+----
+
+{% endfor %}
+
+Key binaries:
+{% for bin in binaries_report %}
+{{ bin }} version -> {{ binaries_report[bin] }}
+{% endfor %}

--- a/roles/operations/tests/inventory
+++ b/roles/operations/tests/inventory
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT
+localhost
+

--- a/roles/operations/tests/test.yml
+++ b/roles/operations/tests/test.yml
@@ -1,0 +1,6 @@
+#SPDX-License-Identifier: MIT
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - operations

--- a/roles/operations/vars/main.yml
+++ b/roles/operations/vars/main.yml
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT
+---
+# vars file for operations


### PR DESCRIPTION
A new role `operations` for checking:
- Systemd service status (active state and unit file state)
- Recent log entries (last 10 lines) for key services, including `fail2ban`, `node_exporter`, and `fogo-validator`
- Binary version check for `fdctl` and it can be extended to check a list of binaries
- Kernel version