### PR TITLE
update fd config and move user creation task before bootstrpping disks

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: firstset # use my own github account for testing for now
 name: fogo_community
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.0.6
+version: 0.0.7
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/validator_service/tasks/bootstrap_disks.yml
+++ b/roles/validator_service/tasks/bootstrap_disks.yml
@@ -67,6 +67,18 @@
     dev: "{{ ledger_disk }}p1"
   when: ledger_disk is defined
 
+- name: Create folders in mounted directories
+  become: true
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
+    mode: "0755"
+  loop:
+    - "/mnt/ledger"
+    - "/mnt/accounts"
+
 - name: Create mount directories
   become: true
   file:
@@ -96,18 +108,6 @@
     opts: defaults,noatime
     state: mounted
   when: ledger_disk is defined
-
-- name: Create folders in mounted directories
-  become: true
-  file:
-    path: "{{ item }}"
-    state: directory
-    owner: "{{ service_user }}"
-    group: "{{ service_user }}"
-    mode: "0755"
-  loop:
-    - "/mnt/ledger"
-    - "/mnt/accounts"
 
 - name: Set correct ownership for mounted directories
   become: true

--- a/roles/validator_service/tasks/build_fogo_fd_client.yml
+++ b/roles/validator_service/tasks/build_fogo_fd_client.yml
@@ -37,7 +37,8 @@
   shell: yes y | ./deps.sh
   args:
     chdir: "{{ temp_source_code_folder }}/fogo"
-  ignore_errors: true
+  retries: 2
+  delay: 5
   tags:
     - update_binary
 

--- a/roles/validator_service/tasks/main.yml
+++ b/roles/validator_service/tasks/main.yml
@@ -7,6 +7,15 @@
       - acl
     update_cache: yes
 
+- name: Create a service user
+  become: true
+  user:
+    name: "{{ service_user }}"
+    shell: "/bin/bash"
+    create_home: true
+    password: "!"
+    state: present
+
 - name: Bootstrap disks (which should be run only once)
   include_tasks: bootstrap_disks.yml
   when: bootstrap_disks
@@ -17,15 +26,6 @@
 
 - name: Update UFW settings for Firedancer
   include_tasks: ufw_settings.yml
-
-- name: Create a service user
-  become: true
-  user:
-    name: "{{ service_user }}"
-    shell: "/bin/bash"
-    create_home: true
-    password: "!"
-    state: present
 
 - name: Update repositories cache and install required libraries
   become: true

--- a/roles/validator_service/templates/firedancer_config_template.toml.j2
+++ b/roles/validator_service/templates/firedancer_config_template.toml.j2
@@ -25,8 +25,7 @@ accounts_path = "{{ accounts_path }}"
 identity_path = "{{ identity_path }}"
 
 expected_genesis_hash = "9GGSFo95raqzZxWqKM5tGYvJp5iv4Dm565S4r8h5PEu9"
-expected_bank_hash = "4bNWYnpUKqMjoZUNUGtc1ZKXpCVGUkZgGCVpc8BQNenn"
-expected_shred_version = 34883
+expected_shred_version = 298
 
 [snapshots]
 full_snapshot_interval_slots = 22500


### PR DESCRIPTION
- Update the config according to https://docs.fogo.io/testnet.html#example-configuration
- Fix the failure when `bootstrap_disks` is enabled by creating the service user before any tasks about bootstrapping disks