### PR TITLE
feat: support vote_account_path configuration, better restart flow

### DIFF
--- a/roles/validator_service/defaults/main.yml
+++ b/roles/validator_service/defaults/main.yml
@@ -9,6 +9,7 @@ validator_client_version: v10.0.0
 validator_client_tarfile_checksum: 5b7b7a18849deb5fd09185828b8c556facd51626
 firedancer_config_path: "/home/{{ service_user }}/firedancer-config.toml"
 identity_path: "/home/{{ service_user }}/unstaked-identity.json"
+vote_account_path: ""
 firedancer_config_template_path: "firedancer_config_template.toml.j2"
 firedancer_systemd_template_path: "firedancer_systemd.j2"
 

--- a/roles/validator_service/defaults/main.yml
+++ b/roles/validator_service/defaults/main.yml
@@ -30,3 +30,7 @@ firedancer_dynamic_port_range: 8901-9000
 install_solana_cli: true
 solana_cli_version: v2.2.20
 solana_cli_config_template_path: "solana_cli.yml.j2"
+
+# if agave-validator is available, we use its wait-for-restart-window subcommand to find a good timing for a restart
+# this option defines the value of option --max-delinquent-stake
+max_delinquent_stake_before_restart: 70

--- a/roles/validator_service/handlers/main.yml
+++ b/roles/validator_service/handlers/main.yml
@@ -1,8 +1,44 @@
 #SPDX-License-Identifier: MIT
 ---
 # handlers file for fogo_validator
-- name: Restart fogo validator service
+
+# handlers for `Restart fogo validator service`
+- name: Check agave-validator availability
+  shell: 'bash -lc "command -v agave-validator"'
+  become: true
+  become_user: "{{ service_user }}"
+  register: agave_validator_check
+  changed_when: false
+  failed_when: false
+  listen: Restart fogo validator service
+
+- name: Wait for restart window
+  shell: >
+    bash -lc
+    'agave-validator --ledger {{ ledger_path }}
+    wait-for-restart-window --max-delinquent-stake {{ max_delinquent_stake_before_restart }}'
+  become: true
+  become_user: "{{ service_user }}"
+  when: agave_validator_check.rc == 0
+  register: wait_cmd
+  changed_when: false
+  listen: Restart fogo validator service
+
+- name: Restart fogo validator
   systemd_service:
     name: fogo-validator
     daemon_reload: true
     state: restarted
+  become: true
+  when: agave_validator_check.rc == 0 and wait_cmd.rc == 0
+  listen: Restart fogo validator service
+
+- name: Restart fogo validator (fallback)
+  systemd_service:
+    name: fogo-validator
+    daemon_reload: true
+    state: restarted
+  become: true
+  when: agave_validator_check.rc != 0
+  listen: Restart fogo validator service
+# handlers for `Restart fogo validator service` end

--- a/roles/validator_service/templates/firedancer_config_template.toml.j2
+++ b/roles/validator_service/templates/firedancer_config_template.toml.j2
@@ -24,6 +24,10 @@ accounts_path = "{{ accounts_path }}"
 # file (generated with solana-keygen new).
 identity_path = "{{ identity_path }}"
 
+# This option is passed to the Agave client with the
+# `--vote-account` argument.
+vote_account_path = "{{ vote_account_path }}"
+
 expected_genesis_hash = "9GGSFo95raqzZxWqKM5tGYvJp5iv4Dm565S4r8h5PEu9"
 expected_shred_version = 298
 


### PR DESCRIPTION
Now users can configure the `vote_account_path`.

When the `fogo-validator.service` needs to be restarted, the workflow is:
- check if `agave-validator` binary is available to user `service_user`
- if so, run `agave-validator --ledger {{ ledger_path }} wait-for-restart-window --max-delinquent-stake {{ max_delinquent_stake_before_restart }}` to wait for a good restart timing, then run `systemctl restart fogo-validator.service`
- if `agave-validator` is not available, directly restart the service using `systemctl restart`