### PR TITLE
#12 support user-defined activation password

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ The main role for bootstrapping a FOGO validator node. See the [role documentati
 
 ### Important Notes Regarding SSH
 
-Please be aware that, with the current implementation, after executing the `node_bootstrapping` tasks, SSH using root user or using a password will be both disabled. If there is at least one sudo user configured using `sudo_users`, the role also configures SSH to only allow the connection from these users. We will provide a flag that allows to keep existing sudo users access in a near further.
+Please be aware that, with the current implementation, after executing the `node_bootstrapping` tasks, SSH using a password will be disabled. SSH using the root user is disabled as well while this can be configured with `disallow_root_login: false/true`. If there is at least one sudo user configured using `sudo_users`, the role also configures SSH to only allow the connection from these users by default. Blocking non-managed sudo users can be disabled by setting `block_non_managed_sudo_users` to `false`.
 
-Considering there can be multiple sudo users to be created and the operator may not want to input the password for each user, the role generates a one-time, expired password for each user. This password is logged in the Ansible output, so please make sure to capture it during the playbook execution. You can use this password for the initial login and then change it immediately after logging in. If the log gets lost, it is safe to rerun the playbook and this one-time password will be regenerated.
+Considering there can be multiple sudo users to be created and the operator may not want to input the password for each user, the role generates a one-time, expired password for each user. It is possible to set the one-time password using `-e "sudo_user_activation_password=<activation_password>"`. This password is logged in the Ansible output, so please make sure to capture it during the playbook execution if it is not set via `sudo_user_activation_password`. A sudo user can use this password for the initial login and then change it immediately after logging in.
 
 Here is an example of the relevant log output:
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: firstset # use my own github account for testing for now
 name: fogo_community
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.0.9
+version: 0.0.10
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/node_bootstrapping/README.md
+++ b/roles/node_bootstrapping/README.md
@@ -55,9 +55,9 @@ Here's an example for a playbook that uses this role:
 
 ### Important Notes Regarding SSH
 
-Please be aware that, with the current implementation, after executing the `node_bootstrapping` tasks, SSH using root user or using a password will be both disabled. If there is at least one sudo user configured using `sudo_users`, the role also configures SSH to only allow the connection from these users. We will provide a flag that allows to keep existing sudo users access in a near further.
+Please be aware that, with the current implementation, after executing the `node_bootstrapping` tasks, SSH using a password will be disabled. SSH using the root user is disabled as well while this can be configured with `disallow_root_login: false/true`. If there is at least one sudo user configured using `sudo_users`, the role also configures SSH to only allow the connection from these users by default. Blocking non-managed sudo users can be disabled by setting `block_non_managed_sudo_users` to `false`.
 
-Considering there can be multiple sudo users to be created and the operator may not want to input the password for each user, the role generates a one-time, expired password for each user. This password is logged in the Ansible output, so please make sure to capture it during the playbook execution. You can use this password for the initial login and then change it immediately after logging in. If the log gets lost, it is safe to rerun the playbook and this one-time password will be regenerated.
+Considering there can be multiple sudo users to be created and the operator may not want to input the password for each user, the role generates a one-time, expired password for each user. It is possible to set the one-time password using `-e "sudo_user_activation_password=<activation_password>"`. This password is logged in the Ansible output, so please make sure to capture it during the playbook execution if it is not set via `sudo_user_activation_password`. A sudo user can use this password for the initial login and then change it immediately after logging in.
 
 Here is an example of the relevant log output:
 

--- a/roles/node_bootstrapping/defaults/main.yml
+++ b/roles/node_bootstrapping/defaults/main.yml
@@ -8,3 +8,15 @@ prometheus_node_ip: null
 enable_ufw: false
 # switch to use the following port for SSH connections instead of port 22
 ssh_port_number: 156
+
+# generate random activation password for each sudo user when it is null
+# when it is set with a string, use the string as activation password for all of the sudo users to be created
+sudo_user_activation_password: null
+
+# if there is at least one sudo user to be created by the role,
+# run a task to set `AllowUsers` in sshd_config to only allow these managed sudo users to remotely login
+block_non_managed_sudo_users: true
+
+# if there is at least one sudo user to be created by the role,
+# set `PermitRootLogin no` in sshd_config when the following option is true
+disallow_root_login: true

--- a/roles/node_bootstrapping/tasks/create_sudo_users.yml
+++ b/roles/node_bootstrapping/tasks/create_sudo_users.yml
@@ -7,22 +7,24 @@
 
 - name: Generate a random password (like a placeholder) that will be set expired in this execution
   set_fact:
-    sudo_user_password: "{{ lookup('ansible.builtin.password', '/dev/null', length=8, chars=['ascii_letters', 'digits']) }}"
+    sudo_user_password_generated: "{{ lookup('ansible.builtin.password', '/dev/null', length=8, chars=['ascii_letters', 'digits']) }}"
   run_once: true
+  when: sudo_user_activation_password is none and user_exists.rc != 0 # return code is non-zero which means the user does not exist yet
 
 - name: Send the following one-time password to the user {{ sudo_username }}, which is needed for creating the real password
   ansible.builtin.debug:
-    msg: "{{ sudo_user_password }}"
+    msg: "{{ (sudo_user_activation_password | default(sudo_user_password_generated, true)) }}"
   run_once: true
+  when: user_exists.rc != 0
 
-- name: Create user {{ sudo_username }} with a random, expired password
+- name: "Create user {{ sudo_username }} with a {{ sudo_user_activation_password is none | ternary('random', 'user-defined') }}, expired password"
   become: true
   user:
     name: "{{ sudo_username }}"
     shell: "/bin/bash"
     create_home: yes
-    password: "{{ sudo_user_password | password_hash('sha512') }}" # Locked password
-  when: user_exists.rc != 0 # return code is non-zero which means the user does not exist yet
+    password: "{{ (sudo_user_activation_password | default(sudo_user_password_generated, true)) | password_hash('sha512') }}" # Locked password
+  when: user_exists.rc != 0
 
 - name: Expire password to force change on first login
   become: true

--- a/roles/node_bootstrapping/tasks/sudo_user_management.yml
+++ b/roles/node_bootstrapping/tasks/sudo_user_management.yml
@@ -13,7 +13,7 @@
     line: "AllowUsers {{ sudo_users.keys() | join(' ') }}"
     state: present
     create: yes
-  when: sudo_users is defined
+  when: sudo_users is defined and block_non_managed_sudo_users is true
 
 - name: Ensure root login is disabled in SSH config since we have created sudo users
   become: true
@@ -22,7 +22,7 @@
     regexp: "^#?PermitRootLogin"
     line: "PermitRootLogin no"
     state: present
-  when: sudo_users is defined
+  when: sudo_users is defined and disallow_root_login is true
 
 - name: Restart SSH service
   service:


### PR DESCRIPTION
This PR also adds the following variables related to sudo user management:

```yaml
# if there is at least one sudo user to be created by the role,
# run a task to set `AllowUsers` in sshd_config to only allow these managed sudo users to remotely login
block_non_managed_sudo_users: true

# if there is at least one sudo user to be created by the role,
# set `PermitRootLogin no` in sshd_config when the following option is true
disallow_root_login: true
```

Close #12 