### PR TITLE
#17 by default outputing firedancer logs to a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ FOGO is a Solana validator client built on Firedancer, designed for high perform
 - **Ansible**: >= 2.9
 - **Target OS**: Ubuntu 20.04+ or Debian 11+
 - **Hardware**: Meets [FOGO's official requirements](https://docs.fogo.io/running-a-node.html)
-- **Network**: Open ports for gossip (8001) and dynamic port range (8901-9000)
+- **Network**: Open ports for gossip (8001), tpu ports (9001, 9007), and dynamic port range (8901-9000)
 
 ## Installation
 

--- a/roles/validator_service/defaults/main.yml
+++ b/roles/validator_service/defaults/main.yml
@@ -4,10 +4,13 @@
 bootstrap_disks: false
 enable_cpu_performance_mode: true
 service_user: fogo
-validator_client_version: v10.0.0
+validator_client_version: v14.0.0
 
-validator_client_tarfile_checksum: 5b7b7a18849deb5fd09185828b8c556facd51626
+validator_client_tarfile_checksum: d5e3493a7192cbb3713f92870205c085b0fa163d
 firedancer_config_path: "/home/{{ service_user }}/firedancer-config.toml"
+# setting the log path to `-` means outputing logs to stdout
+# we use a file instead to avoid duplicating logs to syslog
+firedancer_log_path: "/home/{{ service_user }}/firedancer-validator.log"
 identity_path: "/home/{{ service_user }}/unstaked-identity.json"
 vote_account_path: ""
 firedancer_config_template_path: "firedancer_config_template.toml.j2"

--- a/roles/validator_service/handlers/main.yml
+++ b/roles/validator_service/handlers/main.yml
@@ -34,3 +34,8 @@
   when: agave_validator_check.rc != 0 or wait_cmd.rc != 0
   listen: Restart fogo validator service
 # handlers for `Restart fogo validator service` end
+
+- name: Run logrotate now
+  ansible.builtin.systemd:
+    name: logrotate.service
+    state: started

--- a/roles/validator_service/tasks/main.yml
+++ b/roles/validator_service/tasks/main.yml
@@ -82,8 +82,10 @@
     - name: "{{ identity_path }} does not exist, create a new one for now"
       become: true
       become_user: "{{ service_user }}"
-      shell: "fdctl keys new identity --config {{ firedancer_config_path }}"
+      shell: "fdctl keys new {{ identity_path }}"
       when: not identity_keypair_stat.stat.exists
+  tags:
+    - update_config
 
 - name: Create the systemd service for fogo
   become: true
@@ -91,6 +93,32 @@
     src: "{{ firedancer_systemd_template_path }}"
     dest: "/etc/systemd/system/fogo-validator.service"
     mode: "0644"
+  tags:
+    - update_config
+
+- name: Configure log rotation if Firedancer logs are written to a file
+  become: true
+  block:
+    - name: Ensure logrotate is installed
+      ansible.builtin.package:
+        name: logrotate
+        state: present
+
+    - name: Install logrotate rule for Firedancer
+      ansible.builtin.copy:
+        dest: /etc/logrotate.d/firedancer
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          {{ firedancer_log_path }} {
+            rotate 7
+            daily
+            missingok
+            copytruncate
+          }
+      notify: Run logrotate now
+  when: "firedancer_log_path != '-'"
   tags:
     - update_config
 

--- a/roles/validator_service/tasks/ufw_settings.yml
+++ b/roles/validator_service/tasks/ufw_settings.yml
@@ -15,3 +15,17 @@
     rule: allow
     port: "{{ firedancer_gossip_port }}"
     comment: "firedancer gossip port"
+
+- name: Open tpu port
+  community.general.ufw:
+    rule: allow
+    port: "9001"
+    proto: udp
+    comment: "tpu port"
+
+- name: Open tpu-quic port
+  community.general.ufw:
+    rule: allow
+    port: "9007"
+    proto: udp
+    comment: "tpu quic port"

--- a/roles/validator_service/templates/firedancer_config_template.toml.j2
+++ b/roles/validator_service/templates/firedancer_config_template.toml.j2
@@ -36,8 +36,7 @@ full_snapshot_interval_slots = 22500
 
 [log]
 level_logfile = "INFO"
-# Defaults to stdout, but you can set this to a file to persist logs.
-path = "-"
+path = "{{ firedancer_log_path }}"
 
 [rpc]
 port = 8899


### PR DESCRIPTION
This PR includes the following updates:

- default to output firedancer logs to a file
- update the default fogo firedancer binary version
- update ufw settings to include tpu ports (9001 and 9007)