### PR TITLE
Fix fdctl key generation not using config file

### DIFF
--- a/roles/validator_service/tasks/main.yml
+++ b/roles/validator_service/tasks/main.yml
@@ -82,7 +82,7 @@
     - name: "{{ identity_path }} does not exist, create a new one for now"
       become: true
       become_user: "{{ service_user }}"
-      shell: "fdctl keys new {{ identity_path }}"
+      shell: "fdctl --config {{ firedancer_config_path }} keys new {{ identity_path }}"
       when: not identity_keypair_stat.stat.exists
   tags:
     - update_config


### PR DESCRIPTION
Currently, we are getting the following issue because the key generation is not using the config file


```
[ERROR]: Task failed: Module failed: non-zero return code
Origin: /home/awc/.ansible/collections/ansible_collections/firstset/fogo_community/roles/validator_service/tasks/main.yml:82:7

80       register: identity_keypair_stat
81
82     - name: "{{ identity_path }} does not exist, create a new one for now"
         ^ column 7

fatal: [fogolondon]: FAILED! => {"changed": true, "cmd": "fdctl keys new /home/fogo/unstaked-identity.json", "delta": "0:00:00.011604", "end": "2025-09-27 05:52:51.782062", "msg": "non-zero return code", "rc": 1, "start": "2025-09-27 05:52:51.770458", "stderr": "\u001b[31mERR    \u001b[0m 09-27 05:52:51.780259 81598  f0   0    src/app/shared/fd_config.c(278): running as uid 1003, but config specifies uid 1002", "stderr_lines": ["\u001b[31mERR    \u001b[0m 09-27 05:52:51.780259 81598  f0   0    src/app/shared/fd_config.c(278): running as uid 1003, but config specifies uid 1002"], "stdout": "", "stdout_lines": []}
```